### PR TITLE
Upgrade to gradle 7.1.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,21 +15,17 @@ android {
 }
 
 repositories {
-    mavenLocal()
-    maven {
-        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "$rootDir/../node_modules/react-native/android"
+    if (project == rootProject) {
+        maven { url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror" }
+    } else {
+        // When building as a dep, the RN's maven repo is locally in the node_modules folder
+        def nodeModulesPath = "${project.buildDir}/../../node_modules/"
+        maven { url "${nodeModulesPath}/react-native/android" }
     }
-    maven {
-        // Android JSC is installed from npm
-        url "$rootDir/../node_modules/jsc-android/dist"
-    }
+
     google()
     jcenter()
     mavenCentral()
-    maven {
-        url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror"
-    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.android.library"
+    id "maven-publish"
 }
 
 android {
@@ -35,5 +36,17 @@ dependencies {
     } else {
         //noinspection GradleDynamicVersion
         api "com.facebook.react:react-native:+"
+    }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                groupId = 'com.github.wordpress-mobile'
+                artifactId = 'react-native-linear-gradient'
+            }
+        }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,20 +1,10 @@
+plugins {
+    id "com.android.library"
+}
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
-
-buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath rootProject.ext.has('gradleBuildTools') ? rootProject.ext.get('gradleBuildTools') : 'com.android.tools.build:gradle:3.5.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,18 +2,12 @@ plugins {
     id "com.android.library"
 }
 
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}
-
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 28)
-    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
+    compileSdkVersion 30
+
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 28)
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion 21
+        targetSdkVersion 30
     }
     lintOptions {
         abortOnError false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,7 @@
+org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.caching=true
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,9 @@
+pluginManagement {
+    plugins {
+        id("com.android.library") version "4.2.2"
+    }
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}


### PR DESCRIPTION
This PR is part of [Gradle 7 upgrade for react-native libraries for Gutenberg](https://github.com/WordPress/gutenberg/pull/34048). There are 13 libraries that are upgraded to Gradle 7 and they follow the general outline below:

* Gradle version upgraded to 7.1.1 with `./gradlew wrapper --gradle-version=7.1.1 --distribution-type=all` command. There were a few cases where `gradlew` file was missing or wasn't executable, and these were also addressed as part of this change.
* Gradle plugins are moved to `settings.gradle.kts` file by utilizing Plugin DSL. Since only one settings file is executed per build, except for composite builds, this allows us to change the plugin versions from the root project. For example, [all these projects are added to `react-native-bridge` as a project dependency](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-bridge/android/settings.gradle#L14-L37) and [now that `react-native-bridge` itself uses Plugin DSL](https://github.com/WordPress/gutenberg/pull/34048/files#diff-e0b35174a44c650c42f00c9b0ac7dc0a73fa7c19a1288f48c44301ff4e22065aR1-R20), it can set the Android Gradle plugin & Kotlin plugin version without making changes to these libraries. This should make our lives easier when it comes to upgrading to new versions of Android Gradle plugin.
* Simplifies `android` extension by removing the fancy `minSdk`, `targetSdk` etc setting. If these need to be updated I think they should be done directly as a PR and the fancy code is just making things harder to follow. It's also perfectly fine for a library to be on a lower version if it works fine with it. I think this setting is much more important for applications.
* Updates `repositories` & `dependencies` sections of the build file. I am still not super happy with this one, but it'll need to be improved again at a later time, possibly with the new Gradle 7 dependency management features. Most of them are exactly the same, with a few exceptions where it was necessary.
* Updates or adds `gradle.properties`. I went for a simple version which should work pretty much all the time.
* Adds `maven-publish` plugin and sets up the `publishing` block. This allows Jitpack to publish the artifacts and with this update we are actually only one step away from publishing them to S3 :shrug:
* Either removes `jitpack.yml` where it's not necessary, or simplifies it greatly by only including what's necessary - such as switching to a different directory because Jitpack can't find the project.

There might be some minor changes for a few projects, but hopefully they'll be self-explanatory. Also the first few PRs I opened may be a little different, but it seems to work and I think we can live with that inconsistency. There is just too many PRs to keep everything straight in my head :(

**To test**

These changes can be tested as part of the [gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3833) or [WordPress-Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15076) which is [updated to use the bundle generated with these changes](https://github.com/wordpress-mobile/WordPress-Android/pull/15076/files#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R11). Having said that, I think it's best to leave the testing step to the gutenberg PR review since even if we merge these PRs in, it won't impact anything until [we update the `package.json` file](https://github.com/WordPress/gutenberg/pull/34048/files#diff-1f256578dd9ab8dda6c3913a55a588312129f3404bb0cdf0b1ab52f0a6937119) that adds these libraries. So, worst case scenario, we just open a follow up PR to fix any issues we find during testing. It's up to the reviewer to decide how to go about testing.

**Follow up**

Once these PRs are merged in, we'll create a new tag for each library and [update the `package.json` file](https://github.com/WordPress/gutenberg/pull/34048/files#diff-1f256578dd9ab8dda6c3913a55a588312129f3404bb0cdf0b1ab52f0a6937119) again.
